### PR TITLE
fix init(extendedJSON:) for numbers > Int32.max

### DIFF
--- a/Sources/ExtendedJSON.swift
+++ b/Sources/ExtendedJSON.swift
@@ -287,7 +287,7 @@ extension Document {
                     
                     let numberString = json[numberStart..<position]
                     
-                    // Determine the type: default to int32, but if it contains a ., double
+                    // Determine the type: default to int32(or int64 if needed), but if it contains a ., double
                     if numberString.contains(".") {
                         guard let number = Double(numberString) else {
                             throw ExtendedJSONError.numberParseError(position: numberStart)
@@ -295,11 +295,15 @@ extension Document {
                         
                         value = number
                     } else {
-                        guard let number = Int32(numberString) else {
-                            throw ExtendedJSONError.numberParseError(position: numberStart)
+                        if let number = Int32(numberString) {
+                            value = number
+                        } else {
+                            guard let number = Int64(numberString) else {
+                                throw ExtendedJSONError.numberParseError(position: numberStart)
+                            }
+                            
+                            value = number
                         }
-                        
-                        value = number
                     }
                 case _ where try checkLiteral("true"):
                     value = true


### PR DESCRIPTION
While working with some of Facebook API I got JSON with timestamp and time that exceed Int32.max. This commit adds fix for such numbers and treat them as Int64, meanwhile all other numbers stay as Int32.

Example JSON string:

{"entry":[{"id":"184958674386927","messaging":[{"delivery":{"mids":["mid.2849586746783:987c9b2345"],"seq":0,"watermark":1486345874435},"recipient":{"id":"184958674386927"},"sender":{"id":"1475689234576892"},"timestamp":1486345874649}],"time":1486345874650}],"object":"page"}