### PR TITLE
fix crash with Int64 negative numbers

### DIFF
--- a/Sources/ValueConvertible.swift
+++ b/Sources/ValueConvertible.swift
@@ -308,7 +308,7 @@ extension Int64 : BSONPrimitive {
 
 extension Int : ValueConvertible {
     public func makeBSONPrimitive() -> BSONPrimitive {
-        if (self < Int(Int32.max)) {
+        if self >= Int(Int32.min) && self <= Int(Int32.max) {
             return Int32(self)
         }
         return Int64(self)

--- a/Tests/BSONTests/BSONPublicTests.swift
+++ b/Tests/BSONTests/BSONPublicTests.swift
@@ -98,11 +98,17 @@ final class BSONPublicTests: XCTestCase {
     func testInt() {
         let doc: Document = [
             "int32": 1,
-            "int64": (Int(Int32.max) + 5)
+            "int32Max": Int(Int32.max),
+            "int32Min": Int(Int32.min),
+            "int64Positive": (Int(Int32.max) + 5),
+            "int64Negative": (Int(Int32.min) - 5)
         ]
         
         XCTAssertEqual(doc.type(at: "int32"), .int32)
-        XCTAssertEqual(doc.type(at: "int64"), .int64)
+        XCTAssertEqual(doc.type(at: "int32Max"), .int32)
+        XCTAssertEqual(doc.type(at: "int32Min"), .int32)
+        XCTAssertEqual(doc.type(at: "int64Positive"), .int64)
+        XCTAssertEqual(doc.type(at: "int64Negative"), .int64)
     }
     
     func testAppendingContents() {


### PR DESCRIPTION
Numbers that exceeds Int32.min in negative range - cause crash. 
Also changed extreme values (Int32.max and Int32.min) to stay in Int32 range. 