### PR TITLE
Added support for setting BSONDecoder.userInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .build
 /Packages
 *.xcodeproj
+Package.resolved

--- a/Sources/BSON/Codable.swift
+++ b/Sources/BSON/Codable.swift
@@ -484,7 +484,7 @@ fileprivate class _BSONDecoder : Decoder, _BSONCodingPathContaining {
     
     var codingPath: [CodingKey]
     
-    var userInfo: [CodingUserInfoKey : Any]
+    public var userInfo: [CodingUserInfoKey : Any]
     
     func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
         let container = _BSONKeyedDecodingContainer<Key>(decoder: self, codingPath: self.codingPath)

--- a/Tests/BSONTests/BSONCodableTests.swift
+++ b/Tests/BSONTests/BSONCodableTests.swift
@@ -118,5 +118,267 @@ class BSONCodableTests: XCTestCase {
         XCTAssertEqual(["King", "Queen"], cat.otherNames)
     }
     
+    @available(OSX 10.12, *)
+    func testUserInfo() {
+        
+        let nonCodable = NonCodable()
+        
+        var container = NonCodableContainer (label: "A", nonCodable: nonCodable)
+        XCTAssertEqual ("A", container.label)
+        XCTAssertTrue (container.nonCodable === nonCodable)
+        // Error (userInfo does not container the expected value)
+        let encoder = BSONEncoder()
+        var decoder = BSONDecoder()
+        var document = Document()
+        do {
+            document = try encoder.encode(container)
+        } catch {
+            XCTFail ("Expected success but got \(error)")
+        }
+        do {
+            try container = decoder.decode(NonCodableContainer.self, from: document)
+            XCTFail ("Expected Error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: nil)
+        do {
+            try container = decoder.decode(NonCodableContainer.self, from: document)
+            XCTFail ("Expected Error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: [:])
+        do {
+            try container = decoder.decode(NonCodableContainer.self, from: document)
+            XCTFail ("Expected Error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        // userInfo contains nonCodable
+        let userInfo: [CodingUserInfoKey : Any] = [NonCodableContainer.nonCodableKey : nonCodable]
+        decoder = BSONDecoder (userInfo: userInfo)
+        do {
+            try container = decoder.decode(NonCodableContainer.self, from: document)
+            XCTAssertEqual ("A", container.label)
+            XCTAssertTrue (nonCodable === container.nonCodable)
+        } catch {
+            XCTFail ("Expected success")
+        }
+        // Test Decoding of Array<AnswerContainer> which depends on userInfo
+        // No nonCodable in userInfo
+        let nonCodableArray = [NonCodableContainer (label:"A", nonCodable: nonCodable), NonCodableContainer (label:"B", nonCodable: nonCodable)]
+        do {
+            document = try encoder.encode(nonCodableArray)
+        } catch {
+            XCTFail ("Expected success")
+        }
+        decoder = BSONDecoder()
+        do {
+            let _ = try decoder.decode(Array<NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: nil)
+        do {
+            let _ = try decoder.decode(Array<NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: [:])
+        do {
+            let _ = try decoder.decode(Array<NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        // userInfo contains nonCodable
+        decoder = BSONDecoder(userInfo: userInfo)
+        do {
+            let decodedArray = try decoder.decode(Array<NonCodableContainer>.self, from: document)
+            XCTAssertEqual (2, decodedArray.count)
+            XCTAssertEqual ("A", decodedArray[0].label)
+            XCTAssertTrue (decodedArray[0].nonCodable === nonCodable)
+            XCTAssertEqual ("B", decodedArray[1].label)
+            XCTAssertTrue (decodedArray[1].nonCodable === nonCodable)
+
+        } catch {
+            XCTFail ("Expected success but got \(error)")
+        }
+        // Test Decoding of Dictionary<String, AnswerContainer> which depends on userInfo
+        // No nonCodable in userInfo
+        let nonCodableDictionary = ["A": NonCodableContainer (label:"A", nonCodable: nonCodable), "B" : NonCodableContainer (label:"B", nonCodable: nonCodable)]
+        do {
+            document = try encoder.encode(nonCodableDictionary)
+        } catch {
+            XCTFail ("Expected success")
+        }
+        decoder = BSONDecoder()
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: nil)
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: [:])
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        // userInfo contains nonCodable
+        decoder = BSONDecoder(userInfo: userInfo)
+        do {
+            let decodedDictionary = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTAssertEqual (2, decodedDictionary.count)
+            XCTAssertEqual ("A", decodedDictionary["A"]!.label)
+            XCTAssertTrue (decodedDictionary["A"]!.nonCodable === nonCodable)
+            XCTAssertEqual ("B", decodedDictionary["B"]!.label)
+            XCTAssertTrue (decodedDictionary["B"]!.nonCodable === nonCodable)
+        } catch {
+            XCTFail ("Expected success but got \(error)")
+        }
+        // Test Decoding of Set<AnswerContainer> which depends on userInfo
+        // No nonCodable in userInfo
+        let nonCodableSet: Set<NonCodableContainer> = [NonCodableContainer (label:"A", nonCodable: nonCodable), NonCodableContainer (label:"B", nonCodable: nonCodable)]
+        do {
+            document = try encoder.encode(nonCodableSet)
+        } catch {
+            XCTFail ("Expected success")
+        }
+        decoder = BSONDecoder()
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: nil)
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        decoder = BSONDecoder(userInfo: [:])
+        do {
+            let _ = try decoder.decode(Dictionary<String, NonCodableContainer>.self, from: document)
+            XCTFail ("Expected error")
+        } catch NonCodableError.noNonCodable {} catch {
+            XCTFail ("Expected NonCodableError.noNonCodable but got \(error)")
+        }
+        // userInfo contains nonCodable
+        decoder = BSONDecoder(userInfo: userInfo)
+        do {
+            let decodedSet = try decoder.decode(Set<NonCodableContainer>.self, from: document)
+            XCTAssertEqual (2, decodedSet.count)
+            for nonCodableContainer in decodedSet {
+                XCTAssertTrue (nonCodableContainer.label == "A" || nonCodableContainer.label == "B")
+                XCTAssertTrue (nonCodableContainer.nonCodable === nonCodable)
+            }
+        } catch {
+            XCTFail ("Expected success but got \(error)")
+        }
+    }
+    
+// See https://github.com/OpenKitten/BSON/issues/43
+//    func testEmptyCodable() {
+//
+//        class EmptyCodable : Codable {}
+//        let encoder = BSONEncoder()
+//        let decoder = BSONDecoder()
+//        var document = Document()
+//        let emptySource = EmptyCodable()
+//        do {
+//            document = try encoder.encode(emptySource)
+//        } catch {
+//            XCTFail ("Expected success but got \(error)")
+//        }
+//        do {
+//            let _ = try decoder.decode(EmptyCodable.self, from: document)
+//        } catch {
+//            XCTFail ("Expected success \(error)")
+//        }
+//        let arrayOfEmptySource = [EmptyCodable(), EmptyCodable()]
+//        do {
+//            document = try encoder.encode(arrayOfEmptySource)
+//        } catch {
+//            XCTFail ("Expected success but got \(error)")
+//        }
+//        // JSONEncoder and JSONDecoder can handle this
+//        do {
+//            let jsonEncoder = JSONEncoder()
+//            let data = try jsonEncoder.encode(arrayOfEmptySource)
+//            let jsonDecoder = JSONDecoder()
+//            let decodedArray = try jsonDecoder.decode ([EmptyCodable].self, from: data)
+//            XCTAssertEqual (2, decodedArray.count)
+//        } catch {
+//            XCTFail ("Expected success but got \(error)")
+//        }
+//    }
+    
 }
+
+// Consructs used for testUserInfo
+
+fileprivate class NonCodable{}
+
+fileprivate enum NonCodableError : Error {
+    case noNonCodable
+}
+
+fileprivate class NonCodableContainer : Codable, Hashable {
+    
+    enum CodingKeys: String, CodingKey {
+        case label
+    }
+    
+    init (label: String, nonCodable: NonCodable) {
+        self.label = label
+        self.nonCodable = nonCodable
+    }
+    
+    required public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        label = try values.decode(String.self, forKey: .label)
+        if let nonCodable = decoder.userInfo[NonCodableContainer.nonCodableKey] as? NonCodable {
+            self.nonCodable = nonCodable
+        } else {
+            throw NonCodableError.noNonCodable
+        }
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(label, forKey: .label)
+    }
+    
+    var hashValue: Int {
+        return label.hashValue
+    }
+    
+    let nonCodable: NonCodable
+    let label: String
+    
+    static let nonCodableKey: CodingUserInfoKey = CodingUserInfoKey (rawValue: "nonCodableKey")!
+}
+
+extension NonCodableContainer : Equatable {
+    static func == (lhs: NonCodableContainer, rhs: NonCodableContainer) -> Bool {
+        return lhs.label == rhs.label && lhs.nonCodable === rhs.nonCodable
+    }
+}
+
 #endif
+
+


### PR DESCRIPTION
This change enables application developers to set BSONDecoder.userInfo. A test was added in BSONCodableTests and it passes on High Sierra but it appears that none of the BSONCodableTests run on Linux so it has not been run there.