### PR TITLE
Fix ObjectId on Linux for Swift 5.0

### DIFF
--- a/Sources/BSON/Types/ObjectId.swift
+++ b/Sources/BSON/Types/ObjectId.swift
@@ -14,7 +14,9 @@ public final class ObjectIdGenerator {
     private var template: ContiguousArray<UInt8>
     
     /// Returns the `ObjectIdGenerator` for the current thread
-    public static var shared: ObjectIdGenerator {
+    ///
+    /// - warning: Note that `ObjectIdGenerator` in itself is not thread-safe. It is advised not to store the value that results from accessing this property. Instead, use it directly: `ObjectIdGenerator.default.generate()`
+    public static var `default`: ObjectIdGenerator {
         if let generator = threadSpecificGenerator.currentValue {
             return generator
         }
@@ -89,7 +91,7 @@ public struct ObjectId {
     }
  
     public init() {
-        self = ObjectIdGenerator.shared.generate()
+        self = ObjectIdGenerator.default.generate()
     }
     
     /// Decodes the ObjectID from the provided (24 character) hexString

--- a/Sources/BSON/Types/ObjectId.swift
+++ b/Sources/BSON/Types/ObjectId.swift
@@ -9,10 +9,11 @@ import NIO
 
 fileprivate let processIdentifier = ProcessInfo.processInfo.processIdentifier
 
-public final class ObjectIdGenerator {
+// ObjectIdGenerator subclasses NSObject so it can be used in the thread dictionary on Linux
+public final class ObjectIdGenerator: NSObject {
     private var template: ContiguousArray<UInt8>
     
-    public init() {
+    public override init() {
         self.template = ContiguousArray<UInt8>(repeating: 0, count: 12)
         
         template.withUnsafeMutableBytes { buffer in


### PR DESCRIPTION
See [this commit](https://github.com/apple/swift-corelibs-foundation/commit/aba7feb1b383213a57a7916bf8bc6d17b6d200e5) on Foundation. Because of this, generating an ObjectId would throw an error on Linux with Swift 5:

`Could not cast value of type 'BSON.ObjectIdGenerator' (0x55f83d7bdb90) to 'Foundation.NSObject' (0x7fc108f1fc48).`

This should fix that.