### PR TITLE
Update BSON.podspec

### DIFF
--- a/BSON.podspec
+++ b/BSON.podspec
@@ -2,14 +2,14 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.13'
   s.ios.deployment_target = '10.0'
   s.name             = 'BSON'
-  s.version          = '7.0.4'
+  s.version          = '7.0.5'
   s.summary          = 'A Swift implementation of the BSON specification'
 
   s.description      = <<-DESC
 APIs designed to parse/serialize as well as encode/decode BSON data.
                        DESC
 
-  s.swift_version = '4.2'
+  s.swift_version = ['5.0', '5.2']
   s.homepage         = 'https://github.com/OpenKitten/BSON'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'joannis' => 'joannis@orlandos.nl' }


### PR DESCRIPTION
Xcode warns that BSON needs to be converted with "Conversion to Swift 5 is available". This bumps Podspec and increments the version so we can make a new CocoaPods version.

<img width="842" alt="Screen Shot 2020-12-17 at 4 15 19 PM" src="https://user-images.githubusercontent.com/714282/102544618-10b31f80-4083-11eb-8f33-96db3d284ddd.png">